### PR TITLE
[BugFix][RA-4] 알람 수정 시 Crash 발생 & UI 미반영 현상

### DIFF
--- a/IntervalAlarm.xcodeproj/project.pbxproj
+++ b/IntervalAlarm.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		1CCF73A62C34DC8A0099E0E1 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 1CCF73A52C34DC8A0099E0E1 /* Kingfisher */; };
 		1CCF73A92C34DD360099E0E1 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1CCF73A72C34DD360099E0E1 /* Images.xcassets */; };
 		1CCF73AA2C34DD360099E0E1 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1CCF73A82C34DD360099E0E1 /* Colors.xcassets */; };
+		1CD0B4022D0140BA0032A2F4 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CD0B4012D0140B40032A2F4 /* Constants.swift */; };
 		1CD9FD242CFD609E00FE13CE /* WeekDayTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CD9FD232CFD608B00FE13CE /* WeekDayTabView.swift */; };
 		1CE9D1752C3AD5720084C2A6 /* Foundation+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE9D1742C3AD5720084C2A6 /* Foundation+Extension.swift */; };
 		1CE9D17B2C3AD9FD0084C2A6 /* AddAlarmFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE9D17A2C3AD9FD0084C2A6 /* AddAlarmFeature.swift */; };
@@ -123,6 +124,7 @@
 		1CCF73852C34DB040099E0E1 /* IntervalAlarmUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IntervalAlarmUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1CCF73A72C34DD360099E0E1 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		1CCF73A82C34DD360099E0E1 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
+		1CD0B4012D0140B40032A2F4 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		1CD9FD232CFD608B00FE13CE /* WeekDayTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekDayTabView.swift; sourceTree = "<group>"; };
 		1CE9D1742C3AD5720084C2A6 /* Foundation+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Foundation+Extension.swift"; sourceTree = "<group>"; };
 		1CE9D17A2C3AD9FD0084C2A6 /* AddAlarmFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAlarmFeature.swift; sourceTree = "<group>"; };
@@ -223,6 +225,7 @@
 		1C3E51B02CF82EE40028B142 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				1CD0B4012D0140B40032A2F4 /* Constants.swift */,
 				1C3E51AE2CF82EE40028B142 /* ApplicationLoader.swift */,
 				1C3E51AF2CF82EE40028B142 /* PermissionHandler.swift */,
 			);
@@ -630,6 +633,7 @@
 				4987C24D2CFABCF900BEFF4C /* AddAlarmButtonView.swift in Sources */,
 				1CF3D9DD2CFB63B400FD32A1 /* SnoozeModel.swift in Sources */,
 				1CF3D9DE2CFB63B400FD32A1 /* AlarmModel.swift in Sources */,
+				1CD0B4022D0140BA0032A2F4 /* Constants.swift in Sources */,
 				1CF3D9DF2CFB63B400FD32A1 /* NotificationRequestModel.swift in Sources */,
 				1CF3D9E02CFB63B400FD32A1 /* SoundModel.swift in Sources */,
 				1CF3D9E12CFB63B400FD32A1 /* DayTimeType.swift in Sources */,

--- a/IntervalAlarm/Common/Constants.swift
+++ b/IntervalAlarm/Common/Constants.swift
@@ -1,0 +1,13 @@
+//
+//  Constants.swift
+//  IntervalAlarm
+//
+//  Created by 오지연 on 12/5/24.
+//
+import Foundation
+
+var weekdaySymbols: [String] {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.locale = Locale.current
+    return calendar.shortStandaloneWeekdaySymbols
+}

--- a/IntervalAlarm/Feature/Add/View/WeekDayTabView.swift
+++ b/IntervalAlarm/Feature/Add/View/WeekDayTabView.swift
@@ -20,7 +20,7 @@ struct WeekDayTabView: View {
                     .foregroundStyle(.grey100)
                 
                 HStack(spacing: 10.0) {
-                    ForEach(store.alarm.weekdaySymbols, id: \.self) { day in
+                    ForEach(weekdaySymbols, id: \.self) { day in
                         Text(day)
                             .font(Fonts.Pretendard.medium.swiftUIFont(size: 13))
                             .minimumScaleFactor(0.5)

--- a/IntervalAlarm/Feature/Main/Row/WeekdayDisplayView.swift
+++ b/IntervalAlarm/Feature/Main/Row/WeekdayDisplayView.swift
@@ -13,7 +13,7 @@ struct WeekdayDisplayView: View {
 
     var body: some View {
         HStack(spacing: 5.0) {
-            ForEach(WeekdayDisplayView.weekdaySymbols, id: \.self) { text in
+            ForEach(weekdaySymbols, id: \.self) { text in
                 Circle()
                     .foregroundStyle(selectedWeekdays.contains(text) ? .grey20 : .white100)
                     .overlay {
@@ -25,17 +25,6 @@ struct WeekdayDisplayView: View {
             }
         }
     }
-
-}
-
-
-extension WeekdayDisplayView {
-
-    static var weekdaySymbols: [String] = {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.locale = Locale.current
-        return calendar.shortStandaloneWeekdaySymbols
-    }()
 
 }
 

--- a/IntervalAlarm/Feature/Main/Row/WeekdayDisplayView.swift
+++ b/IntervalAlarm/Feature/Main/Row/WeekdayDisplayView.swift
@@ -33,8 +33,8 @@ extension WeekdayDisplayView {
 
     static var weekdaySymbols: [String] = {
         var calendar = Calendar(identifier: .gregorian)
-        calendar.locale = Locale(identifier: "ko_KR")
-        return calendar.veryShortWeekdaySymbols
+        calendar.locale = Locale.current
+        return calendar.shortStandaloneWeekdaySymbols
     }()
 
 }

--- a/IntervalAlarm/Model/AlarmModel.swift
+++ b/IntervalAlarm/Model/AlarmModel.swift
@@ -91,7 +91,6 @@ extension AlarmModel {
         return calendar.shortStandaloneWeekdaySymbols
     }
     
-    
     var weekdayIds: [String] {
         if self.repeatWeekdaysValue.isEmpty {
             return [self.uuidString]

--- a/IntervalAlarm/Model/AlarmModel.swift
+++ b/IntervalAlarm/Model/AlarmModel.swift
@@ -85,12 +85,6 @@ extension AlarmModel {
         }
     }
     
-    var weekdaySymbols: [String] {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.locale = Locale.current
-        return calendar.shortStandaloneWeekdaySymbols
-    }
-    
     var weekdayIds: [String] {
         if self.repeatWeekdaysValue.isEmpty {
             return [self.uuidString]

--- a/IntervalAlarm/Storage/Client/UserDefaultsClient.swift
+++ b/IntervalAlarm/Storage/Client/UserDefaultsClient.swift
@@ -13,7 +13,7 @@ struct UserDefaultsClient {
     var loadIsLaunchFirst: @Sendable () -> Bool
     var saveIsLaunchFirst: @Sendable (_ isLaunchFirst: Bool) -> Void
     var loadAlarms: @Sendable () -> [AlarmModel]
-    var saveAlarm: @Sendable (_ alarms: AlarmModel) -> Void
+    var saveAlarm: @Sendable (_ alarm: AlarmModel) -> Void
     var saveAlarms: @Sendable (_ alarms: [AlarmModel]) -> Void
     
 }

--- a/IntervalAlarm/Storage/Manager/UserDefaultsStorage.swift
+++ b/IntervalAlarm/Storage/Manager/UserDefaultsStorage.swift
@@ -39,7 +39,11 @@ extension UserDefaultsStorage {
 
     func saveAlarm(model: AlarmModel) {
         var alarms = loadAlarms()
-        alarms.append(model)
+        if alarms.contains(where: { $0.id == model.id }) {
+            alarms = alarms.map { $0.id == model.id ? model : $0 }
+        } else {
+            alarms.append(model)
+        }
         saveObjects(alarms, key: .alarms)
     }
     


### PR DESCRIPTION
- [Jira](https://davidyoon1122.atlassian.net/browse/RA-4?atlOrigin=eyJpIjoiMTg1MzY4MDJiNDAzNDI4OWFmNTE1YTNlMjhiZGRmOGMiLCJwIjoiaiJ9)

## 이슈 1
 - 발생 현상 : 알람 수정 시 Crash 발생
 - 발생 원인 : 이미 존재하는 알람을 중복으로 추가 후 화면에서 그릴 때 id가 겹쳐서 발생하는 문제
 - 수정 방법 : 이미 존재하는 알람을 수정하는 경우 Userdefault에서 교체

## 이슈 2
 - 발생 현상 : 요일 선택 시 메인 UI에 미반영 되는 현상
 - 발생 원인 : WeekdayDisplayView.weekdaySymbols에서 locale 미처리로 인해 같은 값으로 인식하지 못하는 문제
 - 수정 방법 : AlarmModel.weekdaySymbols와 동일한 상태로 변경 처리